### PR TITLE
Changed invoice status argument to state for API v2, made "Bearer" prefix optional in the Personal 

### DIFF
--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -62,7 +62,12 @@ class Harvest(object):
         elif account_id and personal_token:
             self.__auth = 'Bearer'
             self.__account_id = account_id
-            self.__personal_token = personal_token
+
+            if ('Bearer' in personal_token):
+                self.__personal_token = personal_token[personal_token.index('Bearer ') + len('Bearer'):]
+            else:
+                self.__personal_token = personal_token
+
             if put_auth_in_header:
                 self.__headers['Authorization'] = 'Bearer {0}'.format("{self.personal_token}".format(self=self))
                 self.__headers['Harvest-Account-Id'] = "{self.account_id}".format(self=self)
@@ -318,7 +323,7 @@ class Harvest(object):
         if updated_since is not None:
             url = '{0}&updated_since={1}'.format(url, updated_since)
         if status is not None:
-            url = '{0}&status={1}'.format(url, status)
+            url = '{0}&state={1}'.format(url, status)
         if from_date is not None:
             url = '{0}&from={1}'.format(url, from_date)
         if to_date is not None:

--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -318,12 +318,12 @@ class Harvest(object):
 
     ## Invoices
 
-    def invoices(self, page=1, updated_since=None, status=None, from_date=None, to_date=None, client=None):
+    def invoices(self, page=1, updated_since=None, state=None, from_date=None, to_date=None, client=None):
         url = '/invoices?page={0}'.format(page)
         if updated_since is not None:
             url = '{0}&updated_since={1}'.format(url, updated_since)
-        if status is not None:
-            url = '{0}&state={1}'.format(url, status)
+        if state is not None:
+            url = '{0}&state={1}'.format(url, state)
         if from_date is not None:
             url = '{0}&from={1}'.format(url, from_date)
         if to_date is not None:

--- a/harvest/metadata.py
+++ b/harvest/metadata.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 __author__ = "Alex Goretoy"
 __copyright__ = "Copyright 2012-2018, Lionheart Software LLC"
 __maintainer__ = "Dan Loewenherz"


### PR DESCRIPTION
- Made personal token tolerant of having / not having "Bearer" prefix. The Harvest personal token doesn't come issued with that prefix, but it is required for successful connection.
- Invoice option status is currently named state in Harvest API v2. I have changed invoice status argument name to state.