### PR TITLE
Fix 400 error

### DIFF
--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -399,8 +399,9 @@ class Harvest(object):
             'method'  : method,
             'url'     : '{self.uri}{path}'.format(self=self, path=path),
             'headers' : self.__headers,
-            'data'   : json.dumps(data),
         }
+        if data is not None:
+            kwargs['data'] = json.dumps(data)
         if self.auth == 'Basic':
             requestor = requests
             if 'Authorization' not in self.__headers:


### PR DESCRIPTION
The example code
```
import harvest
client = harvest.Harvest("https://COMPANYNAME.harvestapp.com", "EMAIL", "PASSWORD")
client.who_am_i
```
currently results in a 400 error response with the message "HTTP GET requests with a body are not accepted."  This commit removes the request body (which previously evaluated to `'null'`) for requests where the `data` parameter is set to None.